### PR TITLE
Upgrade `bitcoin` to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [dependencies]
 bitcoin_hashes = { version="0.11", optional = true }
 sha2 = { version= "0.10", optional = true }
-bitcoin = { version="0.29", optional = true }
+bitcoin = { version="0.30", optional = true }
 redb = { version = "0.13.0", optional = true }
 
 [features]
@@ -25,7 +25,7 @@ bitcoin = ["dep:bitcoin"]
 
 [dev-dependencies]
 hex_lit = {version = "0.1", features = [ "rust_v_1_46" ] }
-bitcoin = { version="0.29", features = [ "rand" ] }
+bitcoin = { version="0.30", features = [ "rand" ] }
 bitcoin-test-data = "0.2.0"
 tempfile = "3.4.0"
 

--- a/src/bsl/out_point.rs
+++ b/src/bsl/out_point.rs
@@ -88,7 +88,7 @@ impl<'a> Into<bitcoin::OutPoint> for &OutPoint<'a> {
     fn into(self) -> bitcoin::OutPoint {
         use bitcoin::hashes::Hash;
         bitcoin::OutPoint {
-            txid: bitcoin::Txid::from_inner(self.txid().try_into().unwrap()),
+            txid: bitcoin::Txid::from_byte_array(self.txid().try_into().unwrap()),
             vout: self.vout(),
         }
     }


### PR DESCRIPTION
This is a minimal change only upgrading the version and adjusting the code. It does not try to take advantage of the newly added features such as unsized `Script`.

OT: cool crate! I had this idea before, so consider this PR a thank you for making it so that I don't have to. :)