### PR TITLE
sha2: support 0.11 via version range (hardware backends by default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo update -p cc --precise 1.0.28
+      # sha2 0.11 requires Rust 1.85; the committed lock resolves it so
+      # stable/nightly exercise the hardware-backend line — downgrade to
+      # the 0.10 line only for the MSRV build
+      - run: cargo update -p sha2 --precise 0.10.9
+        if: ${{ matrix.toolchain == '1.74.0' }}
 
       - run: cargo build --all-features
         if: ${{ matrix.toolchain == '1.74.0' || matrix.toolchain == 'stable' || matrix.toolchain == 'nightly' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_slices"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "bitcoin-test-data",
@@ -152,11 +152,11 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -198,10 +198,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -269,12 +275,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -300,11 +305,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -335,16 +341,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -396,6 +392,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "itertools"
@@ -759,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -846,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 
 [dependencies]
 bitcoin_hashes = { version = "0.14", optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = ">=0.10, <0.12", optional = true }
 bitcoin = { version = "0.32.0", optional = true }
 redb = { version = "1.0", optional = true }
 hashbrown = { version = "0.14", optional = true }

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -156,9 +156,7 @@ pub fn hash_block_txs(c: &mut Criterion) {
         })
         .bench_function("slices_sha2", |b| {
             b.iter(|| {
-                struct VisitTx(
-                    Vec<sha2::digest::generic_array::GenericArray<u8, sha2::digest::typenum::U32>>,
-                );
+                struct VisitTx(Vec<sha2::digest::Output<sha2::Sha256>>);
                 let mut v = VisitTx(vec![]);
                 impl Visitor for VisitTx {
                     fn visit_block_begin(&mut self, total_transactions: usize) {

--- a/src/bsl/block.rs
+++ b/src/bsl/block.rs
@@ -44,10 +44,7 @@ impl<'a> Block<'a> {
     /// Calculate the block hash using the sha2 crate.
     /// NOTE: the result type is not displayed backwards when converted to string.
     #[cfg(feature = "sha2")]
-    pub fn block_hash_sha2(
-        &self,
-    ) -> crate::sha2::digest::generic_array::GenericArray<u8, crate::sha2::digest::typenum::U32>
-    {
+    pub fn block_hash_sha2(&self) -> crate::sha2::digest::Output<crate::sha2::Sha256> {
         self.header.block_hash_sha2()
     }
 

--- a/src/bsl/block_header.rs
+++ b/src/bsl/block_header.rs
@@ -83,10 +83,7 @@ impl<'a> BlockHeader<'a> {
     /// Calculate the block hash using the sha2 crate.
     /// NOTE: the result type is not displayed backwards when converted to string.
     #[cfg(feature = "sha2")]
-    pub fn block_hash_sha2(
-        &self,
-    ) -> crate::sha2::digest::generic_array::GenericArray<u8, crate::sha2::digest::typenum::U32>
-    {
+    pub fn block_hash_sha2(&self) -> crate::sha2::digest::Output<crate::sha2::Sha256> {
         use crate::sha2::{Digest, Sha256};
         let first = Sha256::digest(self.block_hash_preimage());
         Sha256::digest(&first[..])

--- a/src/bsl/transaction.rs
+++ b/src/bsl/transaction.rs
@@ -109,10 +109,7 @@ impl<'a> Transaction<'a> {
     /// Calculate the txid using the sha2 crate.
     /// NOTE: the result type is not displayed backwards when converted to string.
     #[cfg(feature = "sha2")]
-    pub fn txid_sha2(
-        &self,
-    ) -> crate::sha2::digest::generic_array::GenericArray<u8, crate::sha2::digest::typenum::U32>
-    {
+    pub fn txid_sha2(&self) -> crate::sha2::digest::Output<crate::sha2::Sha256> {
         use crate::sha2::{Digest, Sha256};
         let (a, b, c) = self.txid_preimage();
         let mut hasher = Sha256::new();


### PR DESCRIPTION
## Motivation

sha2 0.11 compiles its hardware SHA256 backends (aarch64 SHA2 extensions,
x86 SHA-NI) in by default, with runtime detection via `cpufeatures`. On
the 0.10 line the aarch64 backend is additionally gated behind the `asm`
feature — so `txid_sha2()` silently runs portable software SHA256 on ARM
hosts unless the consumer knows to enable it. In a downstream indexer
(bindex-based) this was measured at ~72% of the initial-sync CPU profile
on a Cortex-A76.

## Change

- widen the optional dependency to `sha2 = ">=0.10, <0.12"`;
- express the digest return types through the version-agnostic
  `digest::Output<Sha256>` alias. Under a 0.10 resolution this is the
  *same* concrete type as the previous `GenericArray<u8, U32>` spelling,
  so existing consumers see no API change;
- the committed `Cargo.lock` resolves sha2 0.11, so the stable/nightly CI
  jobs exercise the hardware-backend line; the 1.74 MSRV job downgrades
  sha2 to 0.10.9 with a `--precise` step, mirroring the existing `cc`
  pin (sha2 0.11 requires Rust 1.85; the crate's MSRV stays 1.74).

## Validation

- `cargo test --all-features` green on stable with sha2 0.11 (includes
  the txid/block-hash test vectors);
- `cargo check --features bitcoin,sha2` green with sha2 pinned to 0.10.9;
- no new rustfmt/clippy findings (the pre-existing ones that newer
  toolchains report are untouched; CI's pinned 1.82 lint job is
  unaffected).
